### PR TITLE
WorldState.forEach should work for non-square worlds

### DIFF
--- a/lib/conway.dart
+++ b/lib/conway.dart
@@ -38,8 +38,8 @@ class WorldState {
   }
 
   void forEach(WorldStateCallback callback) {
-    for (int x = 0; x < width; ++x) {
-      for (int y = 0; y < width; ++y) {
+    for (int y = 0; y < height; ++y) {
+      for (int x = 0; x < width; ++x) {
         callback(x, y, getAt(x, y));
       }
     }

--- a/test/conway_test.dart
+++ b/test/conway_test.dart
@@ -66,6 +66,22 @@ void main() {
     world.setAt(1, 1, CellState.alive);
     expect(world.countAlive(), 1);
   });
+
+  test('forEach control', () {
+    WorldState world = WorldState(3, 7);
+    expect(world.width, 3);
+    expect(world.height, 7);
+    expect(world.countAlive(), 0);
+    world.setAll(CellState.alive);
+    expect(world.countAlive(), 3 * 7);
+    int count = 0;
+    world.forEach((x, y, value) {
+      ++count;
+      expect(value, CellState.alive);
+    });
+    expect(count, 3 * 7);
+  });
+
   test('one cell dies', () {
     WorldState world = WorldState(4, 4);
     expect(world.countAlive(), 0);


### PR DESCRIPTION
Previously, WorldState.forEach was using the wrong bounds for y, which
did not work correctly for non-square worlds.

Also, change the iteration order to be line-by-line.