### PR TITLE
Add WorldState toString/fromString

### DIFF
--- a/lib/conway.dart
+++ b/lib/conway.dart
@@ -23,6 +23,40 @@ class WorldState {
     _data = Uint8List(width * height);
   }
 
+  factory WorldState.fromString(String pickle) {
+    if (pickle.isEmpty) {
+      return WorldState(0, 0);
+    }
+    List<String> lines = pickle.split('\n');
+    if (lines.length <= 1 || lines.last.isNotEmpty) {
+      throw new ArgumentError(
+          'Each line in pattern must be terminated with a newline (U+0A).');
+    }
+    int height = lines.length - 1;
+    int width = lines[0].length;
+    WorldState world = WorldState(width, height);
+    for (int y = 0; y < height; ++y) {
+      if (lines[y].length != width) {
+        throw new ArgumentError(
+            'Each line in pattern must be the same length. Expected $width. Found ${lines[y].length}.');
+      }
+      for (int x = 0; x < width; ++x) {
+        String ch = lines[y][x];
+        switch (ch) {
+          case 'x':
+            world.setAt(x, y, CellState.alive);
+            break;
+          case '.':
+            // Cells in a newly created world default to dead.
+            break;
+          default:
+            throw new ArgumentError('Invalid character "$ch" in pattern.');
+        }
+      }
+    }
+    return world;
+  }
+
   CellState getAt(int x, int y) {
     if (x < 0 || y < 0 || x >= width || y >= height) {
       return CellState.dead;
@@ -68,6 +102,25 @@ class WorldState {
       }
     });
     return count;
+  }
+
+  @override
+  String toString() {
+    StringBuffer buffer = StringBuffer();
+    for (int y = 0; y < height; y++) {
+      for (int x = 0; x < width; x++) {
+        switch (getAt(x, y)) {
+          case CellState.alive:
+            buffer.write('x');
+            break;
+          case CellState.dead:
+            buffer.write('.');
+            break;
+        }
+      }
+      buffer.write('\n');
+    }
+    return buffer.toString();
   }
 }
 

--- a/test/conway_test.dart
+++ b/test/conway_test.dart
@@ -88,4 +88,101 @@ void main() {
     expect(world.countAlive(), 4);
     expect(newWorld.countAlive(), 4);
   });
+
+  test('toString empty world', () {
+    WorldState world = WorldState(0, 0);
+    expect(world.width, 0);
+    expect(world.height, 0);
+    expect(world.countAlive(), 0);
+    expect(world.toString(), '');
+
+    WorldState reconstructed = WorldState.fromString(world.toString());
+    expect(reconstructed.width, 0);
+    expect(reconstructed.height, 0);
+    expect(reconstructed.countAlive(), 0);
+  });
+
+  test('toString empty 0x5', () {
+    WorldState world = WorldState(0, 5);
+    expect(world.width, 0);
+    expect(world.height, 5);
+    expect(world.countAlive(), 0);
+    expect(world.toString(), '\n\n\n\n\n');
+
+    WorldState reconstructed = WorldState.fromString(world.toString());
+    expect(reconstructed.width, 0);
+    expect(reconstructed.height, 5);
+    expect(reconstructed.countAlive(), 0);
+  });
+
+  test('toString empty 5x0', () {
+    WorldState world = WorldState(5, 0);
+    expect(world.width, 5);
+    expect(world.height, 0);
+    expect(world.countAlive(), 0);
+    expect(world.toString(), '');
+
+    WorldState reconstructed = WorldState.fromString(world.toString());
+    expect(reconstructed.width, 0);
+    expect(reconstructed.height, 0); // Doesn't round-trip.
+    expect(reconstructed.countAlive(), 0);
+  });
+
+  test('toString', () {
+    WorldState world = WorldState(4, 5);
+    expect(world.countAlive(), 0);
+    world.setAt(1, 1, CellState.alive);
+    world.setAt(1, 2, CellState.alive);
+    world.setAt(2, 1, CellState.alive);
+    world.setAt(2, 2, CellState.alive);
+    world.setAt(2, 3, CellState.alive);
+    expect(world.countAlive(), 5);
+    expect(world.toString(), '''
+....
+.xx.
+.xx.
+..x.
+....
+''');
+  });
+
+  test('fromString empty', () {
+    WorldState world = WorldState.fromString('');
+    expect(world.width, 0);
+    expect(world.height, 0);
+    expect(world.countAlive(), 0);
+  });
+
+  test('fromString', () {
+    WorldState world = WorldState.fromString('''
+....
+.xx.
+.xx.
+..x.
+....
+''');
+    expect(world.width, 4);
+    expect(world.height, 5);
+    expect(world.countAlive(), 5);
+    expect(world.getAt(1, 1), CellState.alive);
+    expect(world.getAt(1, 2), CellState.alive);
+    expect(world.getAt(2, 1), CellState.alive);
+    expect(world.getAt(2, 2), CellState.alive);
+    expect(world.getAt(2, 3), CellState.alive);
+  });
+
+  test('fromString invalid', () {
+    expect(() {
+      WorldState.fromString('x');
+    }, throwsArgumentError);
+    expect(() {
+      WorldState.fromString('x\nx');
+    }, throwsArgumentError);
+    expect(() {
+      WorldState.fromString('x\nxx\n');
+    }, throwsArgumentError);
+    expect(() {
+      WorldState.fromString('xy\nxx\n');
+    }, throwsArgumentError);
+  });
 }


### PR DESCRIPTION
This patch lets us serialize and deserialize a WorldState to/from a
string. This functionality will make it easier to test and debug the
logic surrounding the WorldState.

New tests provide 100% line coverage for new or modified code.